### PR TITLE
Connect frontend to new FastAPI budget bet backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,70 +1,92 @@
-# Getting Started with Create React App
+# Budget Bet
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Budget Bet is a social savings challenge where friends compete to stay under budget. The stack is:
 
-## Available Scripts
+- **Frontend**: React + Firebase authentication
+- **Backend**: FastAPI with MongoDB
+- **Bank data**: Plaid API integration point (simulated via stored transactions)
 
-In the project directory, you can run:
+Use it to create groups, propose bets that every member must accept, track everyone’s spending, and automatically crown a winner when the deadline hits.
 
-### `npm start`
+## Prerequisites
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+- Node.js 18+
+- Python 3.10+
+- MongoDB running locally at `mongodb://localhost:27017`
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+## Getting started
 
-### `npm test`
+### 1. Start the API
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
 
-### `npm run build`
+The API is exposed on `http://localhost:8000`. Swagger docs live at `http://localhost:8000/docs`.
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+### 2. Start the React app
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```bash
+npm install
+npm start
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+Set `REACT_APP_API_BASE_URL` in a `.env` file if the API is not running on the default `http://localhost:8000`.
 
-### `npm run eject`
+Firebase authentication is already wired up. Update the configuration under `src/firebase/firebase.js` with your project credentials.
 
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+## Key features
 
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+- Create groups by inviting friends via username
+- Propose, accept, and track bets with a budget cap and deadline
+- Log transactions against bets (simulating Plaid activity)
+- Dashboard summarising active bets, recent winners, and group activity
+- Profile management with Plaid transaction history
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
+## Available scripts
 
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+- `npm start` – run the React development server
+- `npm test` – launch the CRA test runner
+- `npm run build` – production build for the frontend
 
-## Learn More
+## Project structure
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+```
+backend/          # FastAPI service
+src/api/          # Frontend API client wrappers
+src/pages/        # Route-driven React pages
+src/hooks/        # Custom hooks (auth + API helpers)
+```
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+## API overview
 
-### Code Splitting
+| Endpoint | Description |
+|----------|-------------|
+| `POST /api/users/sync` | Upsert a Firebase-authenticated user |
+| `GET /api/groups` | List groups for the signed-in user |
+| `POST /api/groups` | Create a new group and invite members |
+| `POST /api/bets` | Create a bet inside a group |
+| `POST /api/bets/{id}/accept` | Accept a pending bet |
+| `POST /api/bets/{id}/transactions` | Log spending for a bet |
+| `POST /api/bets/{id}/finalize` | Finalise a bet and determine the winner |
+| `GET /api/dashboard/{auth_id}` | Aggregated dashboard data |
+| `GET /api/plaid/transactions/{auth_id}` | Simulated Plaid feed |
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
+All endpoints return JSON and require only the Firebase auth identifier (provided by the frontend) to relate data.
 
-### Analyzing the Bundle Size
+## Testing
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
+- Frontend: `npm test`
+- Backend: use the auto-generated Swagger docs or integrate with your favourite API client.
 
-### Making a Progressive Web App
+## Future enhancements
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
+- Connect the transactions endpoint to real Plaid item access tokens
+- Add push notifications when bets are created or about to end
+- Track recurring budgets and streaks per user
 
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+Happy budgeting!

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,842 @@
+from datetime import datetime, date
+from typing import List, Optional
+
+from bson import ObjectId
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from motor.motor_asyncio import AsyncIOMotorClient
+from pydantic import BaseModel, EmailStr, Field
+from pymongo import ReturnDocument
+
+MONGO_URI = "mongodb://localhost:27017"
+DATABASE_NAME = "hackathon"
+
+try:
+    client = AsyncIOMotorClient(MONGO_URI, serverSelectionTimeoutMS=5000)
+    db = client[DATABASE_NAME]
+    users_collection = db["users"]
+    groups_collection = db["groups"]
+    bets_collection = db["bets"]
+    transactions_collection = db["transactions"]
+    print("✅ Connected to MongoDB successfully!")
+except Exception as exc:  # pragma: no cover - startup log
+    print(f"❌ Failed to connect to MongoDB: {exc}")
+    print("💡 Make sure MongoDB is running on localhost:27017")
+    raise
+
+
+class PyObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value):  # pragma: no cover - validation helper
+        if isinstance(value, ObjectId):
+            return value
+        if not ObjectId.is_valid(value):
+            raise ValueError("Invalid objectid")
+        return ObjectId(value)
+
+
+class UserBase(BaseModel):
+    auth_id: str = Field(..., description="Firebase auth identifier")
+    email: EmailStr
+    username: Optional[str] = None
+    display_name: Optional[str] = None
+    photo_url: Optional[str] = None
+
+
+class UserUpdate(BaseModel):
+    username: Optional[str] = None
+    display_name: Optional[str] = None
+    photo_url: Optional[str] = None
+
+
+class UserResponse(UserBase):
+    id: PyObjectId = Field(alias="_id")
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        json_encoders = {ObjectId: str}
+        allow_population_by_field_name = True
+
+
+class UserPublic(BaseModel):
+    auth_id: str
+    username: Optional[str] = None
+    display_name: Optional[str] = None
+    photo_url: Optional[str] = None
+
+
+class GroupCreate(BaseModel):
+    name: str
+    owner_auth_id: str
+    member_usernames: List[str] = []
+
+
+class GroupMemberAdd(BaseModel):
+    username: str
+
+
+class GroupResponse(BaseModel):
+    id: PyObjectId = Field(alias="_id")
+    name: str
+    owner_auth_id: str
+    members: List[UserPublic]
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        json_encoders = {ObjectId: str}
+        allow_population_by_field_name = True
+
+
+class BetCreate(BaseModel):
+    group_id: PyObjectId
+    created_by: str
+    title: str
+    description: Optional[str] = None
+    budget_limit: float
+    deadline: date
+
+
+class BetAccept(BaseModel):
+    auth_id: str
+
+
+class TransactionCreate(BaseModel):
+    auth_id: str
+    amount: float
+    merchant: str
+    category: Optional[str] = None
+    occurred_on: date
+
+
+class BetParticipant(BaseModel):
+    auth_id: str
+    username: Optional[str] = None
+    display_name: Optional[str] = None
+    photo_url: Optional[str] = None
+    accepted: bool = False
+    spending: float = 0.0
+
+
+class TransactionResponse(BaseModel):
+    id: PyObjectId = Field(alias="_id")
+    bet_id: PyObjectId
+    auth_id: str
+    amount: float
+    merchant: str
+    category: Optional[str] = None
+    occurred_on: date
+    created_at: datetime
+
+    class Config:
+        json_encoders = {ObjectId: str}
+        allow_population_by_field_name = True
+
+
+class BetResponse(BaseModel):
+    id: PyObjectId = Field(alias="_id")
+    group_id: PyObjectId
+    created_by: str
+    title: str
+    description: Optional[str] = None
+    budget_limit: float
+    deadline: date
+    status: str
+    participants: List[BetParticipant]
+    winner_auth_id: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    activated_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    transactions: List[TransactionResponse] = []
+
+    class Config:
+        json_encoders = {ObjectId: str}
+        allow_population_by_field_name = True
+
+
+class DashboardResponse(BaseModel):
+    user: UserPublic
+    groups: List[GroupResponse]
+    active_bets: List[BetResponse]
+    completed_bets: List[BetResponse]
+
+
+app = FastAPI(title="Budget Bet API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+async def fetch_user(auth_id: str) -> Optional[dict]:
+    return await users_collection.find_one({"auth_id": auth_id})
+
+
+def serialize_user(document: dict) -> UserResponse:
+    return UserResponse.parse_obj(document)
+
+
+async def build_public_user(auth_id: str) -> UserPublic:
+    record = await fetch_user(auth_id)
+    if not record:
+        raise HTTPException(status_code=404, detail=f"User {auth_id} not found")
+    return UserPublic(
+        auth_id=record["auth_id"],
+        username=record.get("username"),
+        display_name=record.get("display_name"),
+        photo_url=record.get("photo_url"),
+    )
+
+
+async def build_members(member_ids: List[str]) -> List[UserPublic]:
+    members: List[UserPublic] = []
+    for auth_id in member_ids:
+        try:
+            members.append(await build_public_user(auth_id))
+        except HTTPException:
+            continue
+    return members
+
+
+def normalize_username(username: Optional[str]) -> Optional[str]:
+    return username.strip() if username else None
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await client.admin.command("ismaster")
+
+
+@app.post("/api/users/sync", response_model=UserResponse)
+async def sync_user(payload: UserBase):
+    username = normalize_username(payload.username)
+    existing_username = None
+    if username:
+        username_lower = username.lower()
+        existing_username = await users_collection.find_one(
+            {"username_lower": username_lower, "auth_id": {"$ne": payload.auth_id}}
+        )
+        if existing_username:
+            raise HTTPException(status_code=400, detail="Username already taken")
+
+    now = datetime.utcnow()
+    document = payload.dict()
+    if username:
+        document["username"] = username
+        document["username_lower"] = username.lower()
+
+    document["display_name"] = payload.display_name or payload.username or payload.email.split("@")[0]
+    document["updated_at"] = now
+
+    existing = await fetch_user(payload.auth_id)
+    if existing:
+        await users_collection.update_one({"_id": existing["_id"]}, {"$set": document})
+        existing.update(document)
+        return serialize_user(existing)
+
+    document["created_at"] = now
+    result = await users_collection.insert_one(document)
+    new_user = await users_collection.find_one({"_id": result.inserted_id})
+    return serialize_user(new_user)
+
+
+@app.get("/api/users/{auth_id}", response_model=UserResponse)
+async def get_user(auth_id: str):
+    record = await fetch_user(auth_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="User not found")
+    return serialize_user(record)
+
+
+@app.patch("/api/users/{auth_id}", response_model=UserResponse)
+async def update_user(auth_id: str, payload: UserUpdate):
+    updates = {k: v for k, v in payload.dict().items() if v is not None}
+    if not updates:
+        raise HTTPException(status_code=400, detail="No updates provided")
+
+    if "username" in updates:
+        username = normalize_username(updates["username"])
+        if not username:
+            raise HTTPException(status_code=400, detail="Username cannot be empty")
+        duplicate = await users_collection.find_one(
+            {"username_lower": username.lower(), "auth_id": {"$ne": auth_id}}
+        )
+        if duplicate:
+            raise HTTPException(status_code=400, detail="Username already taken")
+        updates["username"] = username
+        updates["username_lower"] = username.lower()
+
+    updates["updated_at"] = datetime.utcnow()
+
+    document = await users_collection.find_one_and_update(
+        {"auth_id": auth_id},
+        {"$set": updates},
+        return_document=ReturnDocument.AFTER,
+    )
+    if not document:
+        raise HTTPException(status_code=404, detail="User not found")
+    return serialize_user(document)
+
+
+@app.get("/api/users/search", response_model=List[UserPublic])
+async def search_users(query: str):
+    if len(query.strip()) < 2:
+        return []
+    cursor = users_collection.find(
+        {"username_lower": {"$regex": f"^{query.lower()}"}}
+    ).limit(10)
+    results = []
+    async for record in cursor:
+        results.append(
+            UserPublic(
+                auth_id=record["auth_id"],
+                username=record.get("username"),
+                display_name=record.get("display_name"),
+                photo_url=record.get("photo_url"),
+            )
+        )
+    return results
+
+
+@app.post("/api/groups", response_model=GroupResponse)
+async def create_group(payload: GroupCreate):
+    owner = await fetch_user(payload.owner_auth_id)
+    if not owner:
+        raise HTTPException(status_code=404, detail="Owner not found")
+
+    member_ids = {payload.owner_auth_id}
+    for username in payload.member_usernames:
+        user = await users_collection.find_one({"username_lower": username.strip().lower()})
+        if not user:
+            raise HTTPException(status_code=404, detail=f"User {username} not found")
+        member_ids.add(user["auth_id"])
+
+    now = datetime.utcnow()
+    document = {
+        "name": payload.name.strip(),
+        "owner_auth_id": payload.owner_auth_id,
+        "member_auth_ids": sorted(member_ids),
+        "created_at": now,
+        "updated_at": now,
+    }
+    result = await groups_collection.insert_one(document)
+    created = await groups_collection.find_one({"_id": result.inserted_id})
+    members = await build_members(created["member_auth_ids"])
+    return GroupResponse(
+        _id=created["_id"],
+        name=created["name"],
+        owner_auth_id=created["owner_auth_id"],
+        members=members,
+        created_at=created["created_at"],
+        updated_at=created["updated_at"],
+    )
+
+
+@app.get("/api/groups", response_model=List[GroupResponse])
+async def list_groups(auth_id: str):
+    cursor = groups_collection.find({"member_auth_ids": auth_id}).sort("updated_at", -1)
+    groups: List[GroupResponse] = []
+    async for record in cursor:
+        members = await build_members(record["member_auth_ids"])
+        groups.append(
+            GroupResponse(
+                _id=record["_id"],
+                name=record["name"],
+                owner_auth_id=record["owner_auth_id"],
+                members=members,
+                created_at=record["created_at"],
+                updated_at=record["updated_at"],
+            )
+        )
+    return groups
+
+
+@app.get("/api/groups/{group_id}", response_model=GroupResponse)
+async def get_group(group_id: str):
+    if not ObjectId.is_valid(group_id):
+        raise HTTPException(status_code=400, detail="Invalid group id")
+    record = await groups_collection.find_one({"_id": ObjectId(group_id)})
+    if not record:
+        raise HTTPException(status_code=404, detail="Group not found")
+    members = await build_members(record["member_auth_ids"])
+    return GroupResponse(
+        _id=record["_id"],
+        name=record["name"],
+        owner_auth_id=record["owner_auth_id"],
+        members=members,
+        created_at=record["created_at"],
+        updated_at=record["updated_at"],
+    )
+
+
+@app.post("/api/groups/{group_id}/members", response_model=GroupResponse)
+async def add_group_member(group_id: str, payload: GroupMemberAdd):
+    if not ObjectId.is_valid(group_id):
+        raise HTTPException(status_code=400, detail="Invalid group id")
+    username = payload.username.strip().lower()
+    user = await users_collection.find_one({"username_lower": username})
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    document = await groups_collection.find_one_and_update(
+        {"_id": ObjectId(group_id)},
+        {
+            "$addToSet": {"member_auth_ids": user["auth_id"]},
+            "$set": {"updated_at": datetime.utcnow()},
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if not document:
+        raise HTTPException(status_code=404, detail="Group not found")
+    members = await build_members(document["member_auth_ids"])
+    return GroupResponse(
+        _id=document["_id"],
+        name=document["name"],
+        owner_auth_id=document["owner_auth_id"],
+        members=members,
+        created_at=document["created_at"],
+        updated_at=document["updated_at"],
+    )
+
+
+@app.post("/api/bets", response_model=BetResponse)
+async def create_bet(payload: BetCreate):
+    group = await groups_collection.find_one({"_id": payload.group_id})
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+    if payload.created_by not in group["member_auth_ids"]:
+        raise HTTPException(status_code=403, detail="Creator must be group member")
+
+    participants: List[BetParticipant] = []
+    for auth_id in group["member_auth_ids"]:
+        public = await build_public_user(auth_id)
+        participants.append(
+            BetParticipant(
+                auth_id=auth_id,
+                username=public.username,
+                display_name=public.display_name,
+                photo_url=public.photo_url,
+                accepted=auth_id == payload.created_by,
+                spending=0.0,
+            )
+        )
+
+    document = {
+        "group_id": payload.group_id,
+        "created_by": payload.created_by,
+        "title": payload.title,
+        "description": payload.description,
+        "budget_limit": payload.budget_limit,
+        "deadline": payload.deadline,
+        "status": "pending",
+        "participants": [participant.dict() for participant in participants],
+        "winner_auth_id": None,
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "activated_at": None,
+        "completed_at": None,
+    }
+
+    if len(participants) == 1:
+        document["status"] = "active"
+        document["activated_at"] = datetime.utcnow()
+
+    result = await bets_collection.insert_one(document)
+    created = await bets_collection.find_one({"_id": result.inserted_id})
+    transactions = []
+    return BetResponse(
+        _id=created["_id"],
+        group_id=created["group_id"],
+        created_by=created["created_by"],
+        title=created["title"],
+        description=created.get("description"),
+        budget_limit=created["budget_limit"],
+        deadline=created["deadline"],
+        status=created["status"],
+        participants=[BetParticipant(**participant) for participant in created["participants"]],
+        winner_auth_id=created.get("winner_auth_id"),
+        created_at=created["created_at"],
+        updated_at=created["updated_at"],
+        activated_at=created.get("activated_at"),
+        completed_at=created.get("completed_at"),
+        transactions=transactions,
+    )
+
+
+async def get_bet_document(bet_id: str) -> dict:
+    if not ObjectId.is_valid(bet_id):
+        raise HTTPException(status_code=400, detail="Invalid bet id")
+    bet = await bets_collection.find_one({"_id": ObjectId(bet_id)})
+    if not bet:
+        raise HTTPException(status_code=404, detail="Bet not found")
+    return bet
+
+
+async def aggregate_transactions(bet_id: ObjectId) -> List[TransactionResponse]:
+    cursor = transactions_collection.find({"bet_id": bet_id}).sort("occurred_on", 1)
+    items: List[TransactionResponse] = []
+    async for record in cursor:
+        items.append(
+            TransactionResponse(
+                _id=record["_id"],
+                bet_id=record["bet_id"],
+                auth_id=record["auth_id"],
+                amount=record["amount"],
+                merchant=record["merchant"],
+                category=record.get("category"),
+                occurred_on=record["occurred_on"],
+                created_at=record["created_at"],
+            )
+        )
+    return items
+
+
+async def calculate_status(bet: dict) -> dict:
+    participants = [BetParticipant(**participant) for participant in bet["participants"]]
+    accepted = all(participant.accepted for participant in participants)
+    if bet["status"] == "pending" and accepted:
+        bet["status"] = "active"
+        bet["activated_at"] = datetime.utcnow()
+    return bet
+
+
+@app.get("/api/bets/{bet_id}", response_model=BetResponse)
+async def get_bet(bet_id: str):
+    bet = await get_bet_document(bet_id)
+    bet = await calculate_status(bet)
+    if bet["status"] == "active":
+        await bets_collection.update_one(
+            {"_id": bet["_id"]},
+            {"$set": {"status": bet["status"], "activated_at": bet["activated_at"], "updated_at": datetime.utcnow()}},
+        )
+    transactions = await aggregate_transactions(bet["_id"])
+    return BetResponse(
+        _id=bet["_id"],
+        group_id=bet["group_id"],
+        created_by=bet["created_by"],
+        title=bet["title"],
+        description=bet.get("description"),
+        budget_limit=bet["budget_limit"],
+        deadline=bet["deadline"],
+        status=bet["status"],
+        participants=[BetParticipant(**participant) for participant in bet["participants"]],
+        winner_auth_id=bet.get("winner_auth_id"),
+        created_at=bet["created_at"],
+        updated_at=bet["updated_at"],
+        activated_at=bet.get("activated_at"),
+        completed_at=bet.get("completed_at"),
+        transactions=transactions,
+    )
+
+
+@app.get("/api/groups/{group_id}/bets", response_model=List[BetResponse])
+async def list_group_bets(group_id: str):
+    if not ObjectId.is_valid(group_id):
+        raise HTTPException(status_code=400, detail="Invalid group id")
+    cursor = bets_collection.find({"group_id": ObjectId(group_id)}).sort("created_at", -1)
+    bets: List[BetResponse] = []
+    async for record in cursor:
+        transactions = await aggregate_transactions(record["_id"])
+        bets.append(
+            BetResponse(
+                _id=record["_id"],
+                group_id=record["group_id"],
+                created_by=record["created_by"],
+                title=record["title"],
+                description=record.get("description"),
+                budget_limit=record["budget_limit"],
+                deadline=record["deadline"],
+                status=record["status"],
+                participants=[BetParticipant(**participant) for participant in record["participants"]],
+                winner_auth_id=record.get("winner_auth_id"),
+                created_at=record["created_at"],
+                updated_at=record["updated_at"],
+                activated_at=record.get("activated_at"),
+                completed_at=record.get("completed_at"),
+                transactions=transactions,
+            )
+        )
+    return bets
+
+
+@app.post("/api/bets/{bet_id}/accept", response_model=BetResponse)
+async def accept_bet(bet_id: str, payload: BetAccept):
+    bet = await get_bet_document(bet_id)
+    updated = False
+    for participant in bet["participants"]:
+        if participant["auth_id"] == payload.auth_id:
+            participant["accepted"] = True
+            updated = True
+            break
+    if not updated:
+        raise HTTPException(status_code=404, detail="Participant not found")
+
+    bet = await calculate_status(bet)
+    bet["updated_at"] = datetime.utcnow()
+    await bets_collection.update_one(
+        {"_id": bet["_id"]},
+        {
+            "$set": {
+                "participants": bet["participants"],
+                "status": bet["status"],
+                "activated_at": bet.get("activated_at"),
+                "updated_at": bet["updated_at"],
+            }
+        },
+    )
+    transactions = await aggregate_transactions(bet["_id"])
+    return BetResponse(
+        _id=bet["_id"],
+        group_id=bet["group_id"],
+        created_by=bet["created_by"],
+        title=bet["title"],
+        description=bet.get("description"),
+        budget_limit=bet["budget_limit"],
+        deadline=bet["deadline"],
+        status=bet["status"],
+        participants=[BetParticipant(**participant) for participant in bet["participants"]],
+        winner_auth_id=bet.get("winner_auth_id"),
+        created_at=bet["created_at"],
+        updated_at=bet["updated_at"],
+        activated_at=bet.get("activated_at"),
+        completed_at=bet.get("completed_at"),
+        transactions=transactions,
+    )
+
+
+@app.post("/api/bets/{bet_id}/transactions", response_model=BetResponse)
+async def add_transaction(bet_id: str, payload: TransactionCreate):
+    bet = await get_bet_document(bet_id)
+    if bet["status"] not in {"active", "pending"}:
+        raise HTTPException(status_code=400, detail="Bet is not active")
+
+    if payload.amount <= 0:
+        raise HTTPException(status_code=400, detail="Amount must be positive")
+
+    participant = None
+    for item in bet["participants"]:
+        if item["auth_id"] == payload.auth_id:
+            participant = item
+            break
+    if not participant:
+        raise HTTPException(status_code=404, detail="Participant not part of this bet")
+
+    transaction_doc = {
+        "bet_id": bet["_id"],
+        "auth_id": payload.auth_id,
+        "amount": payload.amount,
+        "merchant": payload.merchant,
+        "category": payload.category,
+        "occurred_on": payload.occurred_on,
+        "created_at": datetime.utcnow(),
+    }
+
+    await transactions_collection.insert_one(transaction_doc)
+    participant["spending"] = round(participant.get("spending", 0.0) + payload.amount, 2)
+    bet["updated_at"] = datetime.utcnow()
+    await bets_collection.update_one(
+        {"_id": bet["_id"]},
+        {
+            "$set": {
+                "participants": bet["participants"],
+                "updated_at": bet["updated_at"],
+            }
+        },
+    )
+
+    transactions = await aggregate_transactions(bet["_id"])
+    return BetResponse(
+        _id=bet["_id"],
+        group_id=bet["group_id"],
+        created_by=bet["created_by"],
+        title=bet["title"],
+        description=bet.get("description"),
+        budget_limit=bet["budget_limit"],
+        deadline=bet["deadline"],
+        status=bet["status"],
+        participants=[BetParticipant(**participant) for participant in bet["participants"]],
+        winner_auth_id=bet.get("winner_auth_id"),
+        created_at=bet["created_at"],
+        updated_at=bet["updated_at"],
+        activated_at=bet.get("activated_at"),
+        completed_at=bet.get("completed_at"),
+        transactions=transactions,
+    )
+
+
+@app.post("/api/bets/{bet_id}/finalize", response_model=BetResponse)
+async def finalize_bet(bet_id: str):
+    bet = await get_bet_document(bet_id)
+    if bet["status"] == "completed":
+        return await get_bet(bet_id)
+
+    transactions = await aggregate_transactions(bet["_id"])
+
+    if not transactions:
+        for participant in bet["participants"]:
+            participant["spending"] = participant.get("spending", 0.0)
+    else:
+        spending_map = {}
+        for transaction in transactions:
+            spending_map.setdefault(transaction.auth_id, 0.0)
+            spending_map[transaction.auth_id] += transaction.amount
+        for participant in bet["participants"]:
+            participant["spending"] = round(spending_map.get(participant["auth_id"], 0.0), 2)
+
+    winner_auth_id = min(
+        bet["participants"],
+        key=lambda participant: participant.get("spending", 0.0),
+    )["auth_id"]
+
+    bet["status"] = "completed"
+    bet["winner_auth_id"] = winner_auth_id
+    bet["completed_at"] = datetime.utcnow()
+    bet["updated_at"] = datetime.utcnow()
+
+    await bets_collection.update_one(
+        {"_id": bet["_id"]},
+        {
+            "$set": {
+                "participants": bet["participants"],
+                "status": bet["status"],
+                "winner_auth_id": bet["winner_auth_id"],
+                "completed_at": bet["completed_at"],
+                "updated_at": bet["updated_at"],
+            }
+        },
+    )
+
+    return BetResponse(
+        _id=bet["_id"],
+        group_id=bet["group_id"],
+        created_by=bet["created_by"],
+        title=bet["title"],
+        description=bet.get("description"),
+        budget_limit=bet["budget_limit"],
+        deadline=bet["deadline"],
+        status=bet["status"],
+        participants=[BetParticipant(**participant) for participant in bet["participants"]],
+        winner_auth_id=bet.get("winner_auth_id"),
+        created_at=bet["created_at"],
+        updated_at=bet["updated_at"],
+        activated_at=bet.get("activated_at"),
+        completed_at=bet.get("completed_at"),
+        transactions=transactions,
+    )
+
+
+@app.get("/api/dashboard/{auth_id}", response_model=DashboardResponse)
+async def dashboard(auth_id: str):
+    user_public = await build_public_user(auth_id)
+    groups = await list_groups(auth_id)
+
+    active_cursor = bets_collection.find(
+        {"participants.auth_id": auth_id, "status": {"$in": ["pending", "active"]}}
+    ).sort("deadline", 1)
+
+    active_bets: List[BetResponse] = []
+    async for record in active_cursor:
+        transactions = await aggregate_transactions(record["_id"])
+        active_bets.append(
+            BetResponse(
+                _id=record["_id"],
+                group_id=record["group_id"],
+                created_by=record["created_by"],
+                title=record["title"],
+                description=record.get("description"),
+                budget_limit=record["budget_limit"],
+                deadline=record["deadline"],
+                status=record["status"],
+                participants=[BetParticipant(**participant) for participant in record["participants"]],
+                winner_auth_id=record.get("winner_auth_id"),
+                created_at=record["created_at"],
+                updated_at=record["updated_at"],
+                activated_at=record.get("activated_at"),
+                completed_at=record.get("completed_at"),
+                transactions=transactions,
+            )
+        )
+
+    completed_cursor = bets_collection.find(
+        {"participants.auth_id": auth_id, "status": "completed"}
+    ).sort("completed_at", -1)
+
+    completed_bets: List[BetResponse] = []
+    async for record in completed_cursor:
+        transactions = await aggregate_transactions(record["_id"])
+        completed_bets.append(
+            BetResponse(
+                _id=record["_id"],
+                group_id=record["group_id"],
+                created_by=record["created_by"],
+                title=record["title"],
+                description=record.get("description"),
+                budget_limit=record["budget_limit"],
+                deadline=record["deadline"],
+                status=record["status"],
+                participants=[BetParticipant(**participant) for participant in record["participants"]],
+                winner_auth_id=record.get("winner_auth_id"),
+                created_at=record["created_at"],
+                updated_at=record["updated_at"],
+                activated_at=record.get("activated_at"),
+                completed_at=record.get("completed_at"),
+                transactions=transactions,
+            )
+        )
+
+    return DashboardResponse(
+        user=user_public,
+        groups=groups,
+        active_bets=active_bets,
+        completed_bets=completed_bets,
+    )
+
+
+@app.get("/api/plaid/transactions/{auth_id}", response_model=List[TransactionResponse])
+async def plaid_transactions(auth_id: str):
+    cursor = transactions_collection.find({"auth_id": auth_id}).sort("occurred_on", -1)
+    transactions: List[TransactionResponse] = []
+    async for record in cursor:
+        transactions.append(
+            TransactionResponse(
+                _id=record["_id"],
+                bet_id=record["bet_id"],
+                auth_id=record["auth_id"],
+                amount=record["amount"],
+                merchant=record["merchant"],
+                category=record.get("category"),
+                occurred_on=record["occurred_on"],
+                created_at=record["created_at"],
+            )
+        )
+    return transactions
+
+
+@app.get("/")
+async def root():
+    return {"message": "Budget Bet API is running", "docs": "/docs"}
+
+
+@app.get("/health")
+async def health_check():
+    try:
+        await client.admin.command("ismaster")
+        return {"status": "healthy", "database": "connected"}
+    except Exception:  # pragma: no cover - network error path
+        return {"status": "unhealthy", "database": "disconnected"}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000, reload=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+motor==3.4.0
+pydantic==1.10.15
+pymongo==4.7.2

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,22 +8,78 @@ import GroupDetails from "./pages/GroupDetails";
 import CreateBet from "./pages/CreateBet";
 import BetDetails from "./pages/BetDetails";
 import Profile from "./pages/Profile";
+import { useAuth } from "./contexts/authContext";
+import { doSignOut } from "./firebase/auth";
 
-import { AuthProvider } from "./contexts/authContext";
-
-// Adjust this import path to wherever your Header actually lives
-// e.g. "./components/header" or "./components/layout/Header"
-
-
-
-// Temporary nav to test routing (remove later)
 function Nav() {
+  const { currentUser, userLoggedIn } = useAuth();
+
   return (
-    <nav style={{ padding: "1rem", background: "#eee" }}>
-      <Link to="/">Dashboard</Link> |{" "}
-      <Link to="/groups">Groups</Link> |{" "}
-      <Link to="/profile">Profile</Link>
-      <Link to="/create-bet">Create Bet</Link> |{" "}
+    <nav className="w-full bg-slate-900 text-white">
+      <div className="max-w-5xl mx-auto flex flex-wrap items-center justify-between px-4 py-3 gap-4">
+        <div className="flex items-center gap-3">
+          <Link to="/" className="font-semibold text-lg tracking-wide">
+            Budget Bet
+          </Link>
+          {userLoggedIn && (
+            <div className="hidden sm:flex gap-3 text-sm text-slate-200">
+              <Link className="hover:underline" to="/">
+                Dashboard
+              </Link>
+              <Link className="hover:underline" to="/groups">
+                Groups
+              </Link>
+              <Link className="hover:underline" to="/create-bet">
+                Create Bet
+              </Link>
+              <Link className="hover:underline" to="/profile">
+                Profile
+              </Link>
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 text-sm">
+          {userLoggedIn && currentUser ? (
+            <>
+              <div className="flex items-center gap-2">
+                {currentUser.photoURL ? (
+                  <img
+                    src={currentUser.photoURL}
+                    alt="avatar"
+                    className="h-8 w-8 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-indigo-600 text-white font-semibold">
+                    {currentUser.displayName?.[0]?.toUpperCase() || "U"}
+                  </span>
+                )}
+                <span className="font-medium text-slate-100">
+                  {currentUser.displayName || currentUser.email}
+                </span>
+              </div>
+              <button
+                onClick={doSignOut}
+                className="rounded-md border border-white/40 px-3 py-1 text-xs font-semibold uppercase tracking-wide hover:bg-white/10"
+              >
+                Sign out
+              </button>
+            </>
+          ) : (
+            <div className="flex items-center gap-3">
+              <Link to="/login" className="hover:underline">
+                Log in
+              </Link>
+              <Link
+                to="/register"
+                className="rounded-md bg-indigo-500 px-3 py-1 font-semibold text-white hover:bg-indigo-600"
+              >
+                Sign up
+              </Link>
+            </div>
+          )}
+        </div>
+      </div>
     </nav>
   );
 }
@@ -31,27 +87,24 @@ function Nav() {
 export default function App() {
   const routesArray = [
     { path: "/", element: <Home /> },
+    { path: "/home", element: <Home /> },
     { path: "/login", element: <Login /> },
     { path: "/register", element: <Register /> },
     { path: "/profile", element: <Profile /> },
-
     { path: "/groups", element: <Groups /> },
     { path: "/groups/:groupId", element: <GroupDetails /> },
-
     { path: "/create-bet", element: <CreateBet /> },
     { path: "/bets/:betId", element: <BetDetails /> },
-
-    
   ];
 
   const routesElement = useRoutes(routesArray);
 
   return (
-    <AuthProvider>
+    <div className="min-h-screen bg-slate-50 text-slate-900">
       <Nav />
-      <div className="w-full min-h-screen flex flex-col">
+      <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col px-4 py-8 sm:py-12">
         {routesElement}
-      </div>
-    </AuthProvider>
+      </main>
+    </div>
   );
 }

--- a/src/api/bets.js
+++ b/src/api/bets.js
@@ -1,0 +1,53 @@
+import { request } from "./client";
+
+export async function createBet(payload) {
+  return request("/api/bets", {
+    method: "POST",
+    body: JSON.stringify({
+      group_id: payload.groupId,
+      created_by: payload.createdBy,
+      title: payload.title,
+      description: payload.description,
+      budget_limit: Number(payload.budgetLimit),
+      deadline: payload.deadline,
+    }),
+  });
+}
+
+export async function fetchBet(betId) {
+  return request(`/api/bets/${betId}`);
+}
+
+export async function acceptBet(betId, authId) {
+  return request(`/api/bets/${betId}/accept`, {
+    method: "POST",
+    body: JSON.stringify({ auth_id: authId }),
+  });
+}
+
+export async function addTransaction(betId, transaction) {
+  return request(`/api/bets/${betId}/transactions`, {
+    method: "POST",
+    body: JSON.stringify({
+      auth_id: transaction.authId,
+      amount: Number(transaction.amount),
+      merchant: transaction.merchant,
+      category: transaction.category || undefined,
+      occurred_on: transaction.occurredOn,
+    }),
+  });
+}
+
+export async function finalizeBet(betId) {
+  return request(`/api/bets/${betId}/finalize`, {
+    method: "POST",
+  });
+}
+
+export async function fetchDashboard(authId) {
+  return request(`/api/dashboard/${authId}`);
+}
+
+export async function fetchPlaidTransactions(authId) {
+  return request(`/api/plaid/transactions/${authId}`);
+}

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,0 +1,30 @@
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:8000";
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`;
+    try {
+      const data = await response.json();
+      message = data?.detail || message;
+    } catch (error) {
+      // ignore json parse issues
+    }
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+export { request };

--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -1,0 +1,32 @@
+import { request } from "./client";
+
+export async function createGroup({ name, ownerAuthId, memberUsernames = [] }) {
+  return request("/api/groups", {
+    method: "POST",
+    body: JSON.stringify({
+      name,
+      owner_auth_id: ownerAuthId,
+      member_usernames: memberUsernames,
+    }),
+  });
+}
+
+export async function fetchGroups(authId) {
+  const params = new URLSearchParams({ auth_id: authId });
+  return request(`/api/groups?${params.toString()}`);
+}
+
+export async function fetchGroup(groupId) {
+  return request(`/api/groups/${groupId}`);
+}
+
+export async function addGroupMember(groupId, username) {
+  return request(`/api/groups/${groupId}/members`, {
+    method: "POST",
+    body: JSON.stringify({ username }),
+  });
+}
+
+export async function fetchGroupBets(groupId) {
+  return request(`/api/groups/${groupId}/bets`);
+}

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,0 +1,42 @@
+import { request } from "./client";
+
+export async function syncUserProfile({
+  authId,
+  email,
+  username,
+  displayName,
+  photoURL,
+}) {
+  if (!authId || !email) {
+    throw new Error("authId and email are required to sync user profile");
+  }
+
+  const payload = {
+    auth_id: authId,
+    email,
+    username: username || undefined,
+    display_name: displayName || undefined,
+    photo_url: photoURL || undefined,
+  };
+
+  return request("/api/users/sync", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function fetchUser(authId) {
+  return request(`/api/users/${authId}`);
+}
+
+export async function updateUser(authId, updates) {
+  return request(`/api/users/${authId}`, {
+    method: "PATCH",
+    body: JSON.stringify(updates),
+  });
+}
+
+export async function searchUsers(query) {
+  const params = new URLSearchParams({ query });
+  return request(`/api/users/search?${params.toString()}`);
+}

--- a/src/firebase/auth.js
+++ b/src/firebase/auth.js
@@ -1,5 +1,5 @@
 import { auth } from '../firebase/firebase';
-import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, GoogleAuthProvider, signInWithPopup } from 'firebase/auth';
 
 import { updateProfile } from 'firebase/auth';
 

--- a/src/hooks/useApiUser.js
+++ b/src/hooks/useApiUser.js
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "../contexts/authContext";
+import { fetchUser, syncUserProfile } from "../api/users";
+
+export function useApiUser() {
+  const { currentUser } = useAuth();
+  const [apiUser, setApiUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const loadUser = useCallback(async () => {
+    if (!currentUser) {
+      setApiUser(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      try {
+        const existing = await fetchUser(currentUser.uid);
+        setApiUser(existing);
+      } catch (fetchError) {
+        const synced = await syncUserProfile({
+          authId: currentUser.uid,
+          email: currentUser.email,
+          username: currentUser.displayName,
+          displayName: currentUser.displayName,
+          photoURL: currentUser.photoURL,
+        });
+        setApiUser(synced);
+      }
+    } catch (err) {
+      setError(err);
+      setApiUser(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentUser]);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      if (!active) return;
+      await loadUser();
+    })();
+    return () => {
+      active = false;
+    };
+  }, [loadUser]);
+
+  return { apiUser, loading, error, refresh: loadUser };
+}

--- a/src/pages/BetDetails.jsx
+++ b/src/pages/BetDetails.jsx
@@ -1,7 +1,340 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import { acceptBet, addTransaction, fetchBet, finalizeBet } from "../api/bets";
+import { useAuth } from "../contexts/authContext";
+import { useApiUser } from "../hooks/useApiUser";
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatDate(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
 export default function BetDetails() {
+  const { betId } = useParams();
+  const { userLoggedIn } = useAuth();
+  const { apiUser, loading: userLoading } = useApiUser();
+  const [bet, setBet] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [message, setMessage] = useState(null);
+  const [transactionError, setTransactionError] = useState(null);
+  const [transactionLoading, setTransactionLoading] = useState(false);
+  const [merchant, setMerchant] = useState("");
+  const [amount, setAmount] = useState("0");
+  const [category, setCategory] = useState("");
+  const [occurredOn, setOccurredOn] = useState("");
+
+  const loadBet = useMemo(
+    () => async () => {
+      if (!betId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchBet(betId);
+        setBet(data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [betId],
+  );
+
+  useEffect(() => {
+    loadBet();
+  }, [loadBet]);
+
+  const participant = useMemo(() => {
+    if (!bet || !apiUser) return null;
+    return bet.participants.find((item) => item.auth_id === apiUser.auth_id);
+  }, [bet, apiUser]);
+
+  const progress = useMemo(() => {
+    if (!bet || !participant) return 0;
+    if (!bet.budget_limit) return 0;
+    return Math.min(100, Math.round(((participant.spending || 0) / bet.budget_limit) * 100));
+  }, [bet, participant]);
+
+  const acceptedCount = bet?.participants.filter((p) => p.accepted).length || 0;
+  const allAccepted = bet ? acceptedCount === bet.participants.length : false;
+
+  const handleAccept = async () => {
+    if (!apiUser) return;
+    setMessage(null);
+    try {
+      const updated = await acceptBet(betId, apiUser.auth_id);
+      setBet(updated);
+      setMessage({ type: "success", text: "Bet accepted – good luck!" });
+    } catch (err) {
+      setMessage({ type: "error", text: err.message });
+    }
+  };
+
+  const handleAddTransaction = async (event) => {
+    event.preventDefault();
+    if (!apiUser) return;
+    setTransactionError(null);
+    setTransactionLoading(true);
+    try {
+      const updated = await addTransaction(betId, {
+        authId: apiUser.auth_id,
+        amount,
+        merchant,
+        category,
+        occurredOn,
+      });
+      setBet(updated);
+      setMerchant("");
+      setAmount("0");
+      setCategory("");
+      setOccurredOn("");
+      setMessage({ type: "success", text: "Purchase added" });
+    } catch (err) {
+      setTransactionError(err.message);
+    } finally {
+      setTransactionLoading(false);
+    }
+  };
+
+  const handleFinalize = async () => {
+    setMessage(null);
+    try {
+      const updated = await finalizeBet(betId);
+      setBet(updated);
+      setMessage({ type: "success", text: "Bet finalized" });
+    } catch (err) {
+      setMessage({ type: "error", text: err.message });
+    }
+  };
+
+  if (!userLoggedIn) {
+    return (
+      <div className="rounded-xl bg-white p-8 text-center shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">Sign in to view this bet</h1>
+        <p className="mt-2 text-slate-600">Log in to view the live standings and add your purchases.</p>
+      </div>
+    );
+  }
+
+  if (userLoading || loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl bg-rose-50 p-6 text-rose-700">
+        Unable to load this bet: {error.message}
+      </div>
+    );
+  }
+
+  if (!bet) {
+    return null;
+  }
+
+  const yourSpend = participant?.spending || 0;
+  const winner = bet.participants.find((p) => p.auth_id === bet.winner_auth_id);
+
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Bet Details Page</h1>
+    <div className="space-y-10">
+      <header className="rounded-2xl bg-white p-8 shadow">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-400">Budget bet</p>
+            <h1 className="text-3xl font-semibold text-slate-900">{bet.title}</h1>
+            <p className="mt-2 text-sm text-slate-600">Deadline {formatDate(bet.deadline)}</p>
+            <p className="mt-2 text-sm text-slate-600">Budget per person {currency.format(bet.budget_limit)}</p>
+            {bet.description && <p className="mt-4 text-slate-600">{bet.description}</p>}
+          </div>
+          <div className="text-right">
+            <span className="rounded-full bg-indigo-100 px-4 py-1 text-xs font-semibold uppercase text-indigo-700">
+              {bet.status}
+            </span>
+            <p className="mt-2 text-xs text-slate-500">
+              {acceptedCount}/{bet.participants.length} accepted • {allAccepted ? "Everyone is in" : "Waiting on approvals"}
+            </p>
+            {bet.status === "completed" && winner && (
+              <p className="mt-3 text-sm font-semibold text-emerald-600">
+                Winner: {winner.display_name || winner.username || winner.auth_id}
+              </p>
+            )}
+          </div>
+        </div>
+        {message && (
+          <div
+            className={`mt-6 rounded-lg px-4 py-3 text-sm font-semibold ${
+              message.type === "error" ? "bg-rose-100 text-rose-700" : "bg-emerald-100 text-emerald-700"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+      </header>
+
+      <section className="rounded-2xl bg-white p-8 shadow">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">Your progress</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              You&apos;ve spent {currency.format(yourSpend)} of your {currency.format(bet.budget_limit)} budget.
+            </p>
+          </div>
+          {participant && !participant.accepted && (
+            <button
+              onClick={handleAccept}
+              className="rounded-lg bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+            >
+              Accept bet
+            </button>
+          )}
+        </div>
+        <div className="mt-4 h-3 w-full overflow-hidden rounded-full bg-slate-200">
+          <div
+            className={`h-full rounded-full ${progress > 80 ? "bg-rose-500" : "bg-indigo-500"}`}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+
+        <div className="mt-6 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+          {bet.participants.map((participantItem) => (
+            <div
+              key={participantItem.auth_id}
+              className="flex items-center justify-between rounded-xl border border-slate-200 px-4 py-3"
+            >
+              <div>
+                <p className="font-semibold text-slate-900">
+                  {participantItem.display_name || participantItem.username || participantItem.auth_id}
+                </p>
+                <p className="text-xs text-slate-500">
+                  {participantItem.accepted ? "Accepted" : "Waiting"}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-xs text-slate-400">Spent</p>
+                <p className="text-sm font-semibold text-slate-900">
+                  {currency.format(participantItem.spending || 0)}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {bet.status !== "completed" && participant?.accepted && (
+          <form onSubmit={handleAddTransaction} className="mt-8 space-y-4 rounded-xl border border-slate-200 p-6">
+            <h3 className="text-lg font-semibold text-slate-900">Log a purchase</h3>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="text-sm font-semibold text-slate-600">Merchant</label>
+                <input
+                  type="text"
+                  required
+                  value={merchant}
+                  onChange={(event) => setMerchant(event.target.value)}
+                  placeholder="Groceries, rent, etc."
+                  className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-semibold text-slate-600">Amount</label>
+                <input
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  required
+                  value={amount}
+                  onChange={(event) => setAmount(event.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-semibold text-slate-600">Category</label>
+                <input
+                  type="text"
+                  value={category}
+                  onChange={(event) => setCategory(event.target.value)}
+                  placeholder="Dining, Bills, Travel..."
+                  className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-semibold text-slate-600">Date</label>
+                <input
+                  type="date"
+                  required
+                  value={occurredOn}
+                  onChange={(event) => setOccurredOn(event.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+                />
+              </div>
+            </div>
+            {transactionError && <p className="text-sm font-semibold text-rose-600">{transactionError}</p>}
+            <button
+              type="submit"
+              disabled={transactionLoading}
+              className="inline-flex items-center rounded-lg bg-indigo-500 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-indigo-300"
+            >
+              {transactionLoading ? "Adding..." : "Add transaction"}
+            </button>
+          </form>
+        )}
+
+        {bet.status !== "completed" && (
+          <button
+            onClick={handleFinalize}
+            className="mt-6 inline-flex items-center rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+          >
+            Finalize bet &amp; crown winner
+          </button>
+        )}
+      </section>
+
+      <section className="rounded-2xl bg-white p-8 shadow">
+        <h2 className="text-xl font-semibold text-slate-900">Transactions</h2>
+        {bet.transactions.length === 0 ? (
+          <p className="mt-4 text-sm text-slate-500">No transactions logged yet.</p>
+        ) : (
+          <ul className="mt-4 space-y-3">
+            {bet.transactions.map((transaction) => {
+              const txnParticipant = bet.participants.find((p) => p.auth_id === transaction.auth_id);
+              return (
+                <li
+                  key={transaction._id}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200 px-4 py-3"
+                >
+                  <div>
+                    <p className="font-semibold text-slate-900">{transaction.merchant}</p>
+                    <p className="text-xs text-slate-500">
+                      {txnParticipant?.display_name || txnParticipant?.username || transaction.auth_id} •
+                      {" "}
+                      {transaction.category || "Uncategorized"}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-semibold text-slate-900">
+                      {currency.format(transaction.amount)}
+                    </p>
+                    <p className="text-xs text-slate-500">{formatDate(transaction.occurred_on)}</p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/pages/CreateBet.jsx
+++ b/src/pages/CreateBet.jsx
@@ -1,7 +1,194 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createBet } from "../api/bets";
+import { fetchGroups } from "../api/groups";
+import { useAuth } from "../contexts/authContext";
+import { useApiUser } from "../hooks/useApiUser";
+
 export default function CreateBet() {
+  const navigate = useNavigate();
+  const { userLoggedIn } = useAuth();
+  const { apiUser, loading: userLoading } = useApiUser();
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [formError, setFormError] = useState(null);
+  const [formLoading, setFormLoading] = useState(false);
+  const [groupId, setGroupId] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [budgetLimit, setBudgetLimit] = useState("100");
+  const [deadline, setDeadline] = useState("");
+
+  useEffect(() => {
+    if (!apiUser) return;
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    fetchGroups(apiUser.auth_id)
+      .then((data) => {
+        if (!active) return;
+        setGroups(data);
+        if (data.length > 0) {
+          setGroupId((prev) => prev || data[0]._id);
+        }
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [apiUser]);
+
+  const eligibleGroups = useMemo(() => groups, [groups]);
+
+  const onSubmit = async (event) => {
+    event.preventDefault();
+    if (!apiUser) return;
+    setFormError(null);
+    setFormLoading(true);
+    try {
+      const payload = await createBet({
+        groupId,
+        createdBy: apiUser.auth_id,
+        title,
+        description,
+        budgetLimit,
+        deadline,
+      });
+      navigate(`/bets/${payload._id}`);
+    } catch (err) {
+      setFormError(err.message);
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  if (!userLoggedIn) {
+    return (
+      <div className="rounded-xl bg-white p-8 text-center shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">Sign in to create a bet</h1>
+        <p className="mt-2 text-slate-600">You&apos;ll need to log in before you can challenge your friends.</p>
+      </div>
+    );
+  }
+
+  if (userLoading || loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl bg-rose-50 p-6 text-rose-700">
+        Unable to load groups: {error.message}
+      </div>
+    );
+  }
+
+  if (eligibleGroups.length === 0) {
+    return (
+      <div className="rounded-xl bg-white p-8 text-center shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">Create a group first</h1>
+        <p className="mt-2 text-slate-600">
+          You need to be part of a group before you can propose a bet. Head over to the groups page to start
+          one.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Create bet Page</h1>
+    <div className="rounded-2xl bg-white p-8 shadow">
+      <h1 className="text-2xl font-semibold text-slate-900">Propose a budgeting bet</h1>
+      <p className="mt-2 text-slate-600">Pick your group, set a budget, and challenge everyone to save the most.</p>
+
+      <form onSubmit={onSubmit} className="mt-6 space-y-5">
+        <div>
+          <label className="text-sm font-semibold text-slate-600">Group</label>
+          <select
+            required
+            value={groupId}
+            onChange={(event) => setGroupId(event.target.value)}
+            className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+          >
+            {eligibleGroups.map((group) => (
+              <option key={group._id} value={group._id}>
+                {group.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="text-sm font-semibold text-slate-600">Bet title</label>
+          <input
+            type="text"
+            required
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="February frugal-off"
+            className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label className="text-sm font-semibold text-slate-600">Description</label>
+          <textarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            rows={4}
+            placeholder="Share the rules, prize, or any special conditions."
+            className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="text-sm font-semibold text-slate-600">Budget limit (per person)</label>
+            <input
+              type="number"
+              min="1"
+              step="0.01"
+              required
+              value={budgetLimit}
+              onChange={(event) => setBudgetLimit(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-semibold text-slate-600">Deadline</label>
+            <input
+              type="date"
+              required
+              value={deadline}
+              onChange={(event) => setDeadline(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        {formError && <p className="text-sm font-semibold text-rose-600">{formError}</p>}
+
+        <button
+          type="submit"
+          disabled={formLoading}
+          className="inline-flex items-center rounded-lg bg-indigo-500 px-6 py-3 font-semibold text-white shadow hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-indigo-300"
+        >
+          {formLoading ? "Creating bet..." : "Send bet for approval"}
+        </button>
+      </form>
     </div>
   );
 }

--- a/src/pages/GroupDetails.jsx
+++ b/src/pages/GroupDetails.jsx
@@ -1,7 +1,234 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { addGroupMember, fetchGroup, fetchGroupBets } from "../api/groups";
+import { useAuth } from "../contexts/authContext";
+import { useApiUser } from "../hooks/useApiUser";
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatDate(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
 export default function GroupDetails() {
+  const { groupId } = useParams();
+  const { userLoggedIn } = useAuth();
+  const { apiUser, loading: userLoading } = useApiUser();
+  const [group, setGroup] = useState(null);
+  const [bets, setBets] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [username, setUsername] = useState("");
+  const [formMessage, setFormMessage] = useState(null);
+
+  useEffect(() => {
+    if (!groupId) return;
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([fetchGroup(groupId), fetchGroupBets(groupId)])
+      .then(([groupData, betData]) => {
+        if (!active) return;
+        setGroup(groupData);
+        setBets(betData);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [groupId]);
+
+  const isMember = useMemo(() => {
+    if (!apiUser || !group) return false;
+    return group.members.some((member) => member.auth_id === apiUser.auth_id);
+  }, [apiUser, group]);
+
+  const ownerName = useMemo(() => {
+    if (!group) return null;
+    const owner = group.members.find((member) => member.auth_id === group.owner_auth_id);
+    return owner?.display_name || owner?.username || owner?.auth_id;
+  }, [group]);
+
+  const handleAddMember = async (event) => {
+    event.preventDefault();
+    if (!username.trim()) return;
+    setFormMessage(null);
+    try {
+      const updated = await addGroupMember(groupId, username.trim());
+      setGroup(updated);
+      setUsername("");
+      setFormMessage({ type: "success", text: "Friend added to the group" });
+    } catch (err) {
+      setFormMessage({ type: "error", text: err.message });
+    }
+  };
+
+  if (!userLoggedIn) {
+    return (
+      <div className="rounded-xl bg-white p-8 text-center shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">Sign in to view group details</h1>
+        <p className="mt-2 text-slate-600">Log in to see who&apos;s participating and track your bets.</p>
+      </div>
+    );
+  }
+
+  if (userLoading || loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl bg-rose-50 p-6 text-rose-700">
+        Unable to load this group: {error.message}
+      </div>
+    );
+  }
+
+  if (!group) {
+    return null;
+  }
+
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>GroupDEtails Page</h1>
+    <div className="space-y-10">
+      <header className="rounded-2xl bg-white p-8 shadow">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-400">Group</p>
+            <h1 className="text-3xl font-semibold text-slate-900">{group.name}</h1>
+            <p className="mt-2 text-sm text-slate-600">
+              {group.members.length} member{group.members.length === 1 ? "" : "s"} • Managed by {ownerName}
+            </p>
+          </div>
+          <Link
+            to="/create-bet"
+            className="rounded-lg bg-indigo-500 px-5 py-3 font-semibold text-white shadow hover:bg-indigo-600"
+          >
+            Start a new bet
+          </Link>
+        </div>
+      </header>
+
+      <section className="rounded-2xl bg-white p-8 shadow">
+        <h2 className="text-xl font-semibold text-slate-900">Members</h2>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {group.members.map((member) => (
+            <div
+              key={member.auth_id}
+              className="flex items-center gap-3 rounded-2xl border border-slate-200 px-4 py-3"
+            >
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-500 text-lg font-semibold text-white">
+                {(member.display_name || member.username || "?").slice(0, 1).toUpperCase()}
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-slate-900">
+                  {member.display_name || member.username || member.auth_id}
+                </p>
+                <p className="text-xs text-slate-500">{member.username ? `@${member.username}` : member.auth_id}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {isMember && (
+          <form onSubmit={handleAddMember} className="mt-6 flex flex-wrap gap-3">
+            <input
+              type="text"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              placeholder="Add a friend by username"
+              className="min-w-[220px] flex-1 rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              type="submit"
+              className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700"
+            >
+              Invite
+            </button>
+            {formMessage && (
+              <span
+                className={`text-sm font-semibold ${
+                  formMessage.type === "error" ? "text-rose-600" : "text-emerald-600"
+                }`}
+              >
+                {formMessage.text}
+              </span>
+            )}
+          </form>
+        )}
+      </section>
+
+      <section className="rounded-2xl bg-white p-8 shadow">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Bets in this group</h2>
+          <Link to="/create-bet" className="text-sm font-semibold text-indigo-600 hover:underline">
+            Create bet
+          </Link>
+        </div>
+
+        {bets.length === 0 ? (
+          <div className="mt-6 rounded-xl border border-dashed border-slate-200 p-8 text-center text-slate-500">
+            No bets yet. Start one to challenge your crew.
+          </div>
+        ) : (
+          <div className="mt-6 space-y-4">
+            {bets.map((bet) => (
+              <Link
+                to={`/bets/${bet._id}`}
+                key={bet._id}
+                className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-gradient-to-br from-white to-slate-50 p-6 shadow transition hover:-translate-y-1 hover:border-indigo-200 hover:shadow-lg"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-slate-400">{bet.status}</p>
+                    <h3 className="text-lg font-semibold text-slate-900">{bet.title}</h3>
+                    <p className="text-sm text-slate-500">Deadline {formatDate(bet.deadline)}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-xs text-slate-400">Total budget</p>
+                    <p className="text-base font-semibold text-slate-900">{currency.format(bet.budget_limit)}</p>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {bet.participants.map((participant) => (
+                    <span
+                      key={participant.auth_id}
+                      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
+                        participant.accepted ? "bg-emerald-100 text-emerald-700" : "bg-slate-200 text-slate-600"
+                      }`}
+                    >
+                      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-900 text-white">
+                        {(participant.display_name || participant.username || "?").slice(0, 1).toUpperCase()}
+                      </span>
+                      {participant.display_name || participant.username || participant.auth_id}
+                    </span>
+                  ))}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/pages/Groups.jsx
+++ b/src/pages/Groups.jsx
@@ -1,7 +1,181 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { createGroup, fetchGroups } from "../api/groups";
+import { useAuth } from "../contexts/authContext";
+import { useApiUser } from "../hooks/useApiUser";
+
 export default function Groups() {
+  const { userLoggedIn } = useAuth();
+  const { apiUser, loading: userLoading } = useApiUser();
+  const [groups, setGroups] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [name, setName] = useState("");
+  const [usernames, setUsernames] = useState("");
+  const [formMessage, setFormMessage] = useState(null);
+
+  useEffect(() => {
+    if (!apiUser) return;
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    fetchGroups(apiUser.auth_id)
+      .then((data) => {
+        if (!active) return;
+        setGroups(data);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [apiUser]);
+
+  const handleCreateGroup = async (event) => {
+    event.preventDefault();
+    if (!apiUser) return;
+    setFormMessage(null);
+    try {
+      const additionalUsernames = usernames
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean);
+      await createGroup({
+        name,
+        ownerAuthId: apiUser.auth_id,
+        memberUsernames: additionalUsernames,
+      });
+      setName("");
+      setUsernames("");
+      const refreshed = await fetchGroups(apiUser.auth_id);
+      setGroups(refreshed);
+      setFormMessage({ type: "success", text: "Group created successfully" });
+    } catch (err) {
+      setFormMessage({ type: "error", text: err.message });
+    }
+  };
+
+  if (!userLoggedIn) {
+    return (
+      <div className="rounded-xl bg-white p-8 text-center shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">Sign in to view your groups</h1>
+        <p className="mt-2 text-slate-600">You&apos;ll be able to create a squad and invite friends once you log in.</p>
+      </div>
+    );
+  }
+
+  if (userLoading || loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      </div>
+    );
+  }
+
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Groups Page</h1>
+    <div className="space-y-10">
+      <header className="flex flex-col gap-4 rounded-2xl bg-white p-8 shadow">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">Your budgeting crews</h1>
+          <p className="mt-2 text-slate-600">
+            Create a group, invite your friends by username, and start a savings challenge together.
+          </p>
+        </div>
+
+        <form onSubmit={handleCreateGroup} className="grid gap-4 sm:grid-cols-[1fr_1fr_auto]">
+          <div className="sm:col-span-1">
+            <label className="text-sm font-semibold text-slate-600">Group name</label>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Weekend Warriors"
+              className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div className="sm:col-span-1">
+            <label className="text-sm font-semibold text-slate-600">Invite by username</label>
+            <input
+              type="text"
+              value={usernames}
+              onChange={(event) => setUsernames(event.target.value)}
+              placeholder="comma,separated,handles"
+              className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+            <p className="mt-1 text-xs text-slate-500">Use the usernames your friends picked when signing up.</p>
+          </div>
+          <div className="self-end">
+            <button
+              type="submit"
+              className="w-full rounded-lg bg-indigo-500 px-5 py-3 font-semibold text-white shadow hover:bg-indigo-600"
+            >
+              Create group
+            </button>
+          </div>
+        </form>
+        {formMessage && (
+          <p
+            className={`text-sm ${
+              formMessage.type === "error" ? "text-rose-600" : "text-emerald-600"
+            }`}
+          >
+            {formMessage.text}
+          </p>
+        )}
+      </header>
+
+      {error ? (
+        <div className="rounded-xl bg-rose-50 p-6 text-rose-700">
+          Unable to load groups: {error.message}
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2">
+          {groups.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-slate-200 p-8 text-center text-slate-500">
+              No groups yet. Use the form above to create your first one!
+            </div>
+          ) : (
+            groups.map((group) => (
+              <div key={group._id} className="flex h-full flex-col justify-between rounded-2xl bg-white p-6 shadow">
+                <div>
+                  <h2 className="text-xl font-semibold text-slate-900">{group.name}</h2>
+                  <p className="mt-2 text-sm text-slate-500">
+                    {group.members.length} member{group.members.length === 1 ? "" : "s"}
+                  </p>
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {group.members.map((member) => (
+                      <span
+                        key={member.auth_id}
+                        className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600"
+                      >
+                        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-indigo-500 text-white">
+                          {(member.display_name || member.username || "?").slice(0, 1).toUpperCase()}
+                        </span>
+                        {member.display_name || member.username || member.auth_id}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <Link
+                  to={`/groups/${group._id}`}
+                  className="mt-6 inline-flex items-center justify-center rounded-lg bg-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-600"
+                >
+                  View group →
+                </Link>
+              </div>
+            ))
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,22 +1,268 @@
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { fetchDashboard } from "../api/bets";
+import { useAuth } from "../contexts/authContext";
+import { useApiUser } from "../hooks/useApiUser";
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatDate(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
 
 export default function Home() {
-  return (
-    <div style={{ padding: "2rem" }}>
-      <h1>Dashboard</h1>
-      <p>This is your home page. You can see your groups and active bets here.</p>
+  const { userLoggedIn } = useAuth();
+  const { apiUser, loading: userLoading, error: userError } = useApiUser();
+  const [dashboard, setDashboard] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-      {/* New button to navigate to Create Bet page */}
-      <Link to="/create-bet" style={{
-        display: "inline-block",
-        padding: "0.5rem 1rem",
-        backgroundColor: "#4f46e5",
-        color: "#fff",
-        borderRadius: "0.25rem",
-        textDecoration: "none"
-      }}>
-        Create Bet
-      </Link>
+  useEffect(() => {
+    if (!apiUser) return;
+
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    fetchDashboard(apiUser.auth_id)
+      .then((data) => {
+        if (!active) return;
+        setDashboard(data);
+      })
+      .catch((err) => {
+        if (!active) return;
+        setError(err);
+      })
+      .finally(() => {
+        if (!active) return;
+        setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [apiUser]);
+
+  const activeBets = useMemo(() => dashboard?.active_bets || [], [dashboard]);
+  const completedBets = useMemo(() => dashboard?.completed_bets || [], [dashboard]);
+  const groups = useMemo(() => dashboard?.groups || [], [dashboard]);
+
+  if (!userLoggedIn) {
+    return (
+      <div className="mx-auto w-full max-w-2xl rounded-2xl bg-white p-10 text-center shadow-xl">
+        <h1 className="text-3xl font-bold text-slate-900">Welcome to Budget Bet</h1>
+        <p className="mt-4 text-slate-600">
+          Challenge your friends to budget better. Create groups, start wagers, and track everyone’s
+          spending in real-time.
+        </p>
+        <div className="mt-8 flex justify-center gap-4">
+          <Link
+            to="/login"
+            className="rounded-lg bg-indigo-500 px-6 py-3 font-semibold text-white hover:bg-indigo-600"
+          >
+            Log in
+          </Link>
+          <Link
+            to="/register"
+            className="rounded-lg border border-indigo-500 px-6 py-3 font-semibold text-indigo-500 hover:bg-indigo-50"
+          >
+            Sign up
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (userLoading || loading) {
+    return (
+      <div className="flex w-full justify-center py-12">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (userError) {
+    return (
+      <div className="rounded-xl bg-red-50 p-6 text-red-700">
+        Unable to load your profile: {userError.message}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl bg-red-50 p-6 text-red-700">
+        Unable to load your dashboard: {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      <header className="rounded-2xl bg-white p-8 shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">
+          Hey {dashboard?.user?.display_name || apiUser?.display_name || "there"} 👋
+        </h1>
+        <p className="mt-2 text-slate-600">
+          Here’s what’s happening across your budgeting bets this week.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-4">
+          <Link
+            to="/create-bet"
+            className="rounded-lg bg-indigo-500 px-5 py-3 font-semibold text-white shadow hover:bg-indigo-600"
+          >
+            Create a new bet
+          </Link>
+          <Link
+            to="/groups"
+            className="rounded-lg border border-slate-200 px-5 py-3 font-semibold text-slate-700 hover:bg-slate-50"
+          >
+            Manage groups
+          </Link>
+        </div>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Active bets</h2>
+          {activeBets.length > 0 && (
+            <span className="text-sm text-slate-500">{activeBets.length} currently running</span>
+          )}
+        </div>
+        {activeBets.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-slate-200 p-8 text-center text-slate-500">
+            No active bets yet. Start one with your friends to kick off a budgeting battle!
+          </div>
+        ) : (
+          <div className="grid gap-6 md:grid-cols-2">
+            {activeBets.map((bet) => {
+              const participant = bet.participants.find((p) => p.auth_id === apiUser?.auth_id);
+              const spent = participant?.spending || 0;
+              const progress = Math.min(100, Math.round((spent / bet.budget_limit) * 100));
+              return (
+                <Link
+                  to={`/bets/${bet._id}`}
+                  key={bet._id}
+                  className="group rounded-2xl bg-white p-6 shadow transition hover:-translate-y-1 hover:shadow-lg"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-lg font-semibold text-slate-900 group-hover:text-indigo-600">
+                        {bet.title}
+                      </h3>
+                      <p className="mt-1 text-sm text-slate-500">Deadline: {formatDate(bet.deadline)}</p>
+                    </div>
+                    <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold uppercase text-indigo-600">
+                      {bet.status}
+                    </span>
+                  </div>
+                  <div className="mt-4">
+                    <div className="flex justify-between text-sm text-slate-500">
+                      <span>You&apos;ve spent {currency.format(spent)}</span>
+                      <span>Budget {currency.format(bet.budget_limit)}</span>
+                    </div>
+                    <div className="mt-2 h-2 rounded-full bg-slate-200">
+                      <div
+                        className={`h-full rounded-full ${progress > 80 ? "bg-rose-500" : "bg-indigo-500"}`}
+                        style={{ width: `${progress}%` }}
+                      />
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">Your groups</h2>
+          <Link to="/groups" className="text-sm font-semibold text-indigo-600 hover:underline">
+            View all
+          </Link>
+        </div>
+        {groups.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-slate-200 p-8 text-center text-slate-500">
+            Create a group to invite your friends and start a challenge.
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {groups.slice(0, 4).map((group) => (
+              <Link
+                to={`/groups/${group._id}`}
+                key={group._id}
+                className="rounded-2xl bg-white p-6 shadow transition hover:-translate-y-1 hover:shadow-lg"
+              >
+                <h3 className="text-lg font-semibold text-slate-900">{group.name}</h3>
+                <p className="mt-2 text-sm text-slate-500">
+                  {group.members.length} member{group.members.length === 1 ? "" : "s"}
+                </p>
+                <div className="mt-4 flex -space-x-2">
+                  {group.members.slice(0, 5).map((member) => (
+                    <span
+                      key={member.auth_id}
+                      className="inline-flex h-9 w-9 items-center justify-center rounded-full border-2 border-white bg-indigo-500 text-sm font-semibold text-white"
+                      title={member.display_name || member.username || "Player"}
+                    >
+                      {(member.display_name || member.username || "?")
+                        .toUpperCase()
+                        .slice(0, 2)}
+                    </span>
+                  ))}
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold text-slate-900">Recent winners</h2>
+        {completedBets.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-slate-200 p-8 text-center text-slate-500">
+            No completed bets yet. Keep saving!
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {completedBets.slice(0, 3).map((bet) => {
+              const winner = bet.participants.find((p) => p.auth_id === bet.winner_auth_id);
+              const pot = bet.participants.reduce((acc, participant) => acc + (participant.spending || 0), 0);
+              return (
+                <div
+                  key={bet._id}
+                  className="rounded-2xl bg-white p-6 shadow transition hover:-translate-y-1 hover:shadow-lg"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm uppercase tracking-wide text-slate-400">{formatDate(bet.completed_at)}</p>
+                      <h3 className="text-lg font-semibold text-slate-900">{bet.title}</h3>
+                    </div>
+                    <div className="rounded-full bg-emerald-100 px-4 py-1 text-sm font-semibold text-emerald-700">
+                      Winner: {winner?.display_name || winner?.username || "Unknown"}
+                    </div>
+                  </div>
+                  <p className="mt-4 text-sm text-slate-600">Total tracked spend: {currency.format(pot)}</p>
+                  <Link
+                    to={`/bets/${bet._id}`}
+                    className="mt-4 inline-flex items-center text-sm font-semibold text-indigo-600 hover:underline"
+                  >
+                    View bet summary →
+                  </Link>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,7 +1,197 @@
+import { useEffect, useState } from "react";
+import { fetchPlaidTransactions } from "../api/bets";
+import { updateUser } from "../api/users";
+import { useAuth } from "../contexts/authContext";
+import { useApiUser } from "../hooks/useApiUser";
+
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatDate(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
 export default function Profile() {
+  const { userLoggedIn } = useAuth();
+  const { apiUser, loading, error, refresh } = useApiUser();
+  const [displayName, setDisplayName] = useState("");
+  const [username, setUsername] = useState("");
+  const [photoUrl, setPhotoUrl] = useState("");
+  const [formMessage, setFormMessage] = useState(null);
+  const [formLoading, setFormLoading] = useState(false);
+  const [transactions, setTransactions] = useState([]);
+  const [transactionsLoading, setTransactionsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!apiUser) return;
+    setDisplayName(apiUser.display_name || "");
+    setUsername(apiUser.username || "");
+    setPhotoUrl(apiUser.photo_url || "");
+    setTransactionsLoading(true);
+    fetchPlaidTransactions(apiUser.auth_id)
+      .then((data) => setTransactions(data))
+      .catch(() => setTransactions([]))
+      .finally(() => setTransactionsLoading(false));
+  }, [apiUser]);
+
+  const onSubmit = async (event) => {
+    event.preventDefault();
+    if (!apiUser) return;
+    setFormMessage(null);
+    setFormLoading(true);
+    try {
+      await updateUser(apiUser.auth_id, {
+        display_name: displayName || undefined,
+        username: username || undefined,
+        photo_url: photoUrl || undefined,
+      });
+      await refresh();
+      setFormMessage({ type: "success", text: "Profile updated" });
+    } catch (err) {
+      setFormMessage({ type: "error", text: err.message });
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  if (!userLoggedIn) {
+    return (
+      <div className="rounded-xl bg-white p-8 text-center shadow">
+        <h1 className="text-2xl font-semibold text-slate-900">Sign in to view your profile</h1>
+        <p className="mt-2 text-slate-600">Log in to customize your avatar and track your spending history.</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl bg-rose-50 p-6 text-rose-700">
+        Unable to load profile: {error.message}
+      </div>
+    );
+  }
+
+  if (!apiUser) {
+    return null;
+  }
+
+  const totalTracked = transactions.reduce((sum, txn) => sum + (txn.amount || 0), 0);
+
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Profile Page</h1>
+    <div className="space-y-10">
+      <section className="rounded-2xl bg-white p-8 shadow">
+        <div className="flex flex-wrap items-start gap-6">
+          <div className="flex h-20 w-20 items-center justify-center overflow-hidden rounded-full bg-indigo-500 text-3xl font-semibold text-white">
+            {photoUrl ? (
+              <img src={photoUrl} alt={displayName || username || "Avatar"} className="h-full w-full object-cover" />
+            ) : (
+              (displayName || username || "?").slice(0, 1).toUpperCase()
+            )}
+          </div>
+          <div className="flex-1">
+            <h1 className="text-3xl font-semibold text-slate-900">{displayName || username || "Budgeteer"}</h1>
+            <p className="mt-2 text-sm text-slate-600">@{username || "pick-a-username"}</p>
+            <p className="mt-4 text-sm text-slate-500">Joined via {apiUser.email}</p>
+          </div>
+        </div>
+
+        <form onSubmit={onSubmit} className="mt-8 space-y-5">
+          <div>
+            <label className="text-sm font-semibold text-slate-600">Display name</label>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-semibold text-slate-600">Username</label>
+            <input
+              type="text"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              placeholder="unique_handle"
+              className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="text-sm font-semibold text-slate-600">Profile photo URL</label>
+            <input
+              type="url"
+              value={photoUrl}
+              onChange={(event) => setPhotoUrl(event.target.value)}
+              placeholder="https://..."
+              className="mt-1 w-full rounded-lg border border-slate-200 px-4 py-2 focus:border-indigo-500 focus:outline-none"
+            />
+          </div>
+          {formMessage && (
+            <p
+              className={`text-sm ${
+                formMessage.type === "error" ? "text-rose-600" : "text-emerald-600"
+              }`}
+            >
+              {formMessage.text}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={formLoading}
+            className="inline-flex items-center rounded-lg bg-indigo-500 px-6 py-3 font-semibold text-white shadow hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-indigo-300"
+          >
+            {formLoading ? "Saving..." : "Save changes"}
+          </button>
+        </form>
+      </section>
+
+      <section className="rounded-2xl bg-white p-8 shadow">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-xl font-semibold text-slate-900">Recent Plaid transactions</h2>
+          <p className="text-sm text-slate-500">Total tracked: {currency.format(totalTracked)}</p>
+        </div>
+        {transactionsLoading ? (
+          <div className="mt-6 flex justify-center">
+            <div className="h-10 w-10 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+          </div>
+        ) : transactions.length === 0 ? (
+          <p className="mt-4 text-sm text-slate-500">No transactions synced yet.</p>
+        ) : (
+          <ul className="mt-6 space-y-3">
+            {transactions.slice(0, 10).map((transaction) => (
+              <li
+                key={transaction._id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200 px-4 py-3"
+              >
+                <div>
+                  <p className="font-semibold text-slate-900">{transaction.merchant}</p>
+                  <p className="text-xs text-slate-500">{transaction.category || "Uncategorized"}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-sm font-semibold text-slate-900">
+                    {currency.format(transaction.amount)}
+                  </p>
+                  <p className="text-xs text-slate-500">{formatDate(transaction.occurred_on)}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
+import { useNavigate, Navigate, Link } from "react-router-dom";
 import { useAuth } from "../contexts/authContext";
 import {
   doCreateUserWithEmailAndPassword,
-  setAuthDisplayName
+  setAuthDisplayName,
 } from "../firebase/auth";
-import { useNavigate, Navigate, Link } from "react-router-dom";
+import { syncUserProfile } from "../api/users";
 
 const Register = () => {
   const navigate = useNavigate();
@@ -41,10 +42,17 @@ const Register = () => {
       // 1) Create auth user
       const cred = await doCreateUserWithEmailAndPassword(email, password);
 
-      // 2) Store username in Firebase Auth profile (displayName)
-      await setAuthDisplayName(username.trim());
+      const cleanedUsername = username.trim();
+      await setAuthDisplayName(cleanedUsername);
 
-      // 3) Redirect to home (auth context guard will handle)
+      await syncUserProfile({
+        authId: cred.user.uid,
+        email,
+        username: cleanedUsername,
+        displayName: cleanedUsername,
+        photoURL: cred.user.photoURL,
+      });
+
       navigate("/");
     } catch (err) {
       setErrorMessage(err?.message || "Sign up failed.");


### PR DESCRIPTION
## Summary
- add a FastAPI backend that manages users, groups, bets, transactions, and dashboard data in MongoDB
- wire the React app into the API with shared auth syncing, reusable request helpers, and Plaid-style transaction feeds
- rebuild dashboard, group, bet, and profile pages so users can create challenges, accept bets, log spending, and review winners
- refresh project docs with setup instructions for both the API and frontend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d84c20053c83308c364e6dda88b2c1